### PR TITLE
Fix stage deps being based on deps of wrong system

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -278,8 +278,8 @@ impl Scheduler {
                 let id = system.id();
                 system_reads[id.0] = read_deps[counter].iter().copied().collect();
                 system_writes[id.0] = write_deps[counter].iter().copied().collect();
-                stage_read.extend(system_reads[counter].clone());
-                stage_write.extend(system_writes[counter].clone());
+                stage_read.extend(system_reads[id.0].clone());
+                stage_write.extend(system_writes[id.0].clone());
                 systems[id.0] = Some(system);
                 systems_in_stage.push(id);
                 counter += 1;


### PR DESCRIPTION
This fixes #3 

The stage dependencies were filled with dependencies of systems from other stages due to wrong indexing into the `system_read` and `system_write` vecs.